### PR TITLE
Add google analytics to presentation template

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,5 +91,16 @@
 
 		</script>
 
+        <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+            ga('create', 'UA-{GISi Google Analytics Presentation ID}', 'auto');
+            ga('send', 'pageview', '{Presentation Title}');
+
+        </script>
+
 	</body>
 </html>


### PR DESCRIPTION
Add google analytics to presentation template.  This will allow us to track how many hits our presentations get.
